### PR TITLE
use do-while loop style

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -30,17 +30,16 @@ var retryStrategy = retry.Strategy{
 
 // getFooWithRetry demonstrates a retry loop.
 func getFooWithRetry() (*Foo, error) {
-	for i := retryStrategy.Start(nil); i.Next(); {
+	for i := retryStrategy.Start(); ; {
 		log.Printf("getting foo")
 		foo, err := getFoo()
 		if err == nil {
 			return foo, nil
 		}
-		if !i.HasMore() {
+		if !i.Next(nil) {
 			return nil, fmt.Errorf("error getting foo after %d tries: %v", i.Count(), err)
 		}
 	}
-	panic("unreachable")
 }
 
 func getFoo() (*Foo, error) {


### PR DESCRIPTION
The `HasMore` method has always seemed a bit odd,
and also the need to guarantee that a loop will run at least
once. Instead, change the idiomatic loop style from:

```
for i := strategy.Start(nil); i.Next(); {
	doSomething()
}
```

to:

```
i := strategy.Start()
for {
	doSomething()
	if !i.Next(nil) {
		break
	}
}
```

This means that it's obvious by inspection that at least one
try will be made; there's no need for `HasMore` because
the variables associated with the try are all in scope when the
test is made, and if we return inside the `if !i.Next()` body, the
there's no need for a `panic("unreachable")` because the compiler
can see that there's no way for the loop to terminate any other
way.

The down side is that it's a bit more verbose, but I think that
the other points outweigh that consideration.

Also pass the `stop` channel to `Next` rather than to `Start` so
it's a bit clearer that `Next` is the only method that blocks
and therefore needs a way to ask it to stop.